### PR TITLE
Fix for issue #2: support for downloading specific boards/sections

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -201,8 +201,7 @@ def fetch_boards(boards, force_update=False, path=None):
         # Images in board.
         save_dir = os.path.join(
             "images",
-            board['owner']['username'],
-            board['name']
+            os.path.join(*board["url"][1:-1].split("/")),
         )
         images_by_directory[save_dir] = fetch_images(
             "https://www.pinterest.com/resource/BoardFeedResource/get/",
@@ -216,12 +215,10 @@ def fetch_boards(boards, force_update=False, path=None):
             # Images in board sections.
             save_dir = os.path.join(
                 "images",
-                board['owner']['username'],
-                board['name'],
+                os.path.join(*board['url'][1:-1].split("/")),
                 section
             )
-            directory = "/".join((board["url"][1:-1], section))
-            images_by_directory[directory] = fetch_images(
+            images_by_directory[save_dir] = fetch_images(
                 "https://www.pinterest.com/resource/BoardSectionPinsResource/get",
                 board["url"],
                 {"section_id": section_id, "page_size": 25},
@@ -260,7 +257,7 @@ def fetch_boards(boards, force_update=False, path=None):
                             for chunk in response:
                                 img.write(chunk)
                 else:
-                    print("no image found: {}".format(image_id))
+                    print("\nno image found: {}".format(image_id))
                     continue
 
                 print_progress_bar(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -44,99 +44,166 @@ def get_session():
 
 
 def get_user_boards(username):
-    s = get_session()
-    r = s.get("https://www.pinterest.com/{}/".format(username))
-    root = html.fromstring(r.content)
+    session = get_session()
+    request = session.get(
+        "https://www.pinterest.com/{}/".format(username)
+    )
+    root = html.fromstring(request.content)
     tag = root.xpath("//script[@id='initial-state']")[0]
     initial_data = json.loads(tag.text)
     # UserProfileBoardResource
-    boards = [i for i in initial_data['resourceResponses'] if i['name'] == 'UserProfileBoardResource']
-    if boards:
-        boards = boards[0]['response']['data']
-
+    boards_resource = [
+        resource for resource
+        in initial_data['resourceResponses']
+        if resource['name'] == 'UserProfileBoardResource'
+    ]
+    if boards_resource:
+        boards = boards_resource[0]['response']['data']
     return boards
 
 
-def get_board_info(board_name):
-    s = get_session()
+def get_user_board_paths(username):
+    all_boards = get_user_boards(username)
+    return [
+        board["url"][1:-1]
+        for board in all_boards
+    ]
 
-    r = s.get("https://www.pinterest.com/{}/".format(board_name))
-    root = html.fromstring(r.content)
+def get_board_info(board_name):
+    session = get_session()
+    response = session.get(
+        "https://www.pinterest.com/{}/".format(board_name)
+    )
+    root = html.fromstring(response.content)
     tag = root.xpath("//script[@id='initial-state']")[0]
     initial_data = json.loads(tag.text)
+    board = None
+    if "resourceResponses" in initial_data:
+        board = initial_data["resourceResponses"][0]["response"]["data"]
+        try:
+            sections = [
+                (section["slug"], section["id"])
+                for section in (
+                    initial_data
+                    .get("resourceResponses")[2]
+                    .get("response")
+                    .get("data")
+                )
+            ]
+            board["sections"] = sections
+        except (IndexError, KeyError) as e:
+            # Board has no sections!
+            pass
+    elif "resources" in initial_data:
+        board = (
+                initial_data
+                .get('resources')
+                .get('data')
+                .get('BoardPageResource')
+        )[list(boards.keys())[0]]['data']
+    return board
 
-    boards = initial_data['resources'] \
-        ['data'] \
-        ['BoardPageResource']
 
-    boards = boards[list(boards.keys())[0]] \
-        ['data']
+def fetch_boards(boards, force_update=False, path=None):
 
-    return [boards]
+    session = get_session()
 
+    def fetch_images(get_url, board_url, options):
+        bookmark = None
+        images = []
+        while bookmark != '-end-':
+            if bookmark:
+                options.update({ "bookmarks": [bookmark], })
+            response = session.get(
+                get_url,
+                params={
+                    "source_url": board_url,
+                    "data": json.dumps(
+                        {"options": options, "context": {}}
+                    ),
+                }
+            )
+            data = response.json()
+            images += data["resource_response"]["data"]
+            bookmark = data['resource']['options']['bookmarks'][0]
+        return images
 
-def fetch_boards(boards, force_update=False):
-    s = get_session()
+    images_by_directory = {}
+    filter_user, filter_board, filter_section = (path.split("/") + [None, None, None])[:3]
 
     for board_index, board in enumerate(boards):
-        save_dir = os.path.join("images", board['owner']['username'], board['name'])
+        # Images in board.
+        save_dir = os.path.join(
+            "images",
+            board['owner']['username'],
+            board['name']
+        )
+        images_by_directory[save_dir] = fetch_images(
+            "https://www.pinterest.com/resource/BoardFeedResource/get/",
+            board["url"],
+            {"board_id": board['id'], "page_size": 25}
+        )
+        for section, section_id in (board.get("sections") or ()):
+            if filter_section and filter_section != section:
+                # Skip any other sections if requesting specific one.
+                continue
+            # Images in board sections.
+            save_dir = os.path.join(
+                "images",
+                board['owner']['username'],
+                board['name'],
+                section
+            )
+            directory = "/".join((board["url"][1:-1], section))
+            images_by_directory[directory] = fetch_images(
+                "https://www.pinterest.com/resource/BoardSectionPinsResource/get",
+                board["url"],
+                {"section_id": section_id, "page_size": 25},
+            )
 
-        bookmark = None
+        for i, (save_dir, images) in enumerate(images_by_directory.items(), 1):
+            pinterest_path = "/".join(save_dir.split(os.path.sep)[1:])
+            try:
+                os.makedirs(save_dir)
+            except Exception:
+                pass
+            print(
+                "[{}/{}] board: {}, found {} images".format(
+                    i,
+                    len(images),
+                    pinterest_path,
+                    len(images)
+                )
+            )
 
-        images = []
+        for save_dir, images in images_by_directory.items():
+            for i, image in enumerate(images, 1):
+                image_id = image['id']
 
-        while bookmark != '-end-':
-            options = {
-                "board_id": board['id'],
-                "page_size": 25,
-            }
+                if 'images' in image:
+                    url = image['images']['orig']['url']
+                    basename = os.path.basename(url)
+                    _, ext = basename.split(".")
+                    file_path = os.path.join(
+                        save_dir, "{}.{}".format(str(image_id), ext))
 
-            if bookmark:
-                options.update({
-                    "bookmarks": [bookmark],
-                })
+                    if not os.path.exists(file_path) or force_update:
+                        print(url)
+                        r = requests.get(url, stream=True)
 
-            r = s.get("https://www.pinterest.com/resource/BoardFeedResource/get/", params={
-                "source_url": board['url'],
-                "data": json.dumps({
-                    "options": options,
-                    "context": {}
-                }),
-            })
+                        with open(file_path, 'wb') as f:
+                            for chunk in r:
+                                f.write(chunk)
+                else:
+                    print("no image found: {}".format(image_id))
+                    continue
 
-            data = r.json()
-
-            images += data["resource_response"]["data"]
-
-            bookmark = data['resource']['options']['bookmarks'][0]
-
-
-        try:
-            os.makedirs(save_dir)
-        except Exception:
-            pass
-
-        print("[{}/{}] board: {}, found {} images".format(board_index + 1, len(boards), board['url'], len(images)))
-
-        for index, image in enumerate(images):
-            image_id = image['id']
-
-            if 'images' in image:
-                url = image['images']['orig']['url']
-                basename = os.path.basename(url)
-                _, ext = basename.split(".")
-                file_path = os.path.join(save_dir, "{}.{}".format(str(image_id), ext))
-
-                if not os.path.exists(file_path) or force_update:
-                    r = requests.get(url, stream=True)
-
-                    with open(file_path, 'wb') as f:
-                        for chunk in r:
-                            f.write(chunk)
-            else:
-                print("no image found: {}".format(image_id))
-
-            printProgressBar(index + 1, len(images), prefix='Progress:', suffix='Complete', length=50)
+                printProgressBar(
+                    i, len(images),
+                    prefix='Progress:',
+                    suffix='Complete',
+                    length=50
+                )
 
         print()
 
@@ -163,14 +230,17 @@ def get_parser():
 def main():
     """Main entry point."""
     args = get_parser().parse_args()
-
-    if '/' in args.path:
-        boards = get_board_info(args.path)
+    if "/" not in args.path:
+        paths = get_user_board_paths(args.path)
     else:
-        boards = get_user_boards(args.path)
+        paths = [args.path]
 
-    fetch_boards(boards, args.force)
-
+    boards = [get_board_info(path) for path in paths]
+    fetch_boards(
+        boards,
+        force_update=args.force,
+        path=args.path,
+    )
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -173,4 +173,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -141,11 +141,28 @@ def fetch_boards(boards, force_update=False):
         print()
 
 
+def get_parser():
+    """argparse.ArgumentParser: Get argument parser."""
+    parser = argparse.ArgumentParser(
+        description='Download pin boards by username'
+    )
+    parser.add_argument(
+        'path',
+        type=str,
+        help='pinterest username or username/boardname'
+    )
+    parser.add_argument(
+        '-f',
+        '--force',
+        action="store_true",
+        help='force redownload even if image already exists'
+    )
+    return parser
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Download pin boards by username')
-    parser.add_argument('path', type=str, help='pinterest username or username/boardname')
-    parser.add_argument('-f', '--force', type=bool, default=False, help='force redownload even if image already exists')
-    args = parser.parse_args()
+    """Main entry point."""
+    args = get_parser().parse_args()
 
     if '/' in args.path:
         boards = get_board_info(args.path)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,7 @@
+"""pinterest-board-downloader
+
+Download pinterest boards.
+"""
 import argparse
 import json
 import os
@@ -7,18 +11,22 @@ import lxml.html as html
 import requests
 
 
-# Print iterations progress
-def printProgressBar(iteration, total, prefix='', suffix='', decimals=1, length=100, fill='#'):
-    """
+def print_progress_bar(
+        iteration, total, prefix='', suffix='', decimals=1, length=100,
+        fill='#'):
+    """Print iterations progress.
+
     Call in a loop to create terminal progress bar
-    @params:
-        iteration   - Required  : current iteration (Int)
-        total       - Required  : total iterations (Int)
-        prefix      - Optional  : prefix string (Str)
-        suffix      - Optional  : suffix string (Str)
-        decimals    - Optional  : positive number of decimals in percent complete (Int)
-        length      - Optional  : character length of bar (Int)
-        fill        - Optional  : bar fill character (Str)
+
+    Args:
+        iteration (int): current iteration
+        total (int): total iterations
+        prefix (str): prefix string (optional)
+        suffix (str): suffix string (optional)
+        decimals (int): positive number of decimals in percent complete (optional)
+        length (int): character length of bar
+        fill (str): bar fill character (optional)
+
     """
     percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
     filledLength = int(length * iteration // total)
@@ -28,6 +36,7 @@ def printProgressBar(iteration, total, prefix='', suffix='', decimals=1, length=
 
 
 def get_session():
+    """requests.Session: Get requests session."""
     s = requests.Session()
     s.headers = {
         "Host": "www.pinterest.com",
@@ -44,6 +53,15 @@ def get_session():
 
 
 def get_user_boards(username):
+    """Get info for all boards of a user
+
+    Call in a loop to create terminal progress bar
+    @params:
+        username    - Required  : user to query
+
+    Returns:
+        list(dict): data response for multiple boards.
+    """
     session = get_session()
     request = session.get(
         "https://www.pinterest.com/{}/".format(username)
@@ -105,10 +123,27 @@ def get_board_info(board_name):
 
 
 def fetch_boards(boards, force_update=False, path=None):
+    """Download board image data.
+
+    Fetches all images, downloads and writes to disk.
+    Progress is logged to terminal.
+
+    Args:
+        boards (list(dict)): board image data.
+        force_update (bool): re-download existing.
+        path (str): path in the form "user/board/section".
+    """
 
     session = get_session()
 
     def fetch_images(get_url, board_url, options):
+        """Run through get requests, iterating with bookmark hash.
+
+        Args:
+            get_url (str): Get request url.
+            board_url (str): board url to request.
+            options (dict): data to include in request.
+        """
         bookmark = None
         images = []
         while bookmark != '-end-':
@@ -198,7 +233,7 @@ def fetch_boards(boards, force_update=False, path=None):
                     print("no image found: {}".format(image_id))
                     continue
 
-                printProgressBar(
+                print_progress_bar(
                     i, len(images),
                     prefix='Progress:',
                     suffix='Complete',


### PR DESCRIPTION
This fixes issue #2 for the example commands:
```
pinterest henjesuestrella/fashion-men-style
pinterest henjesuestrella/fashion-men-style/formal
```

- Fix download of specific boards
- Add support for boards containing "sections"
- linting (style changes), using pylint as linter